### PR TITLE
Fix PlatformAddress's fromPublic() method

### DIFF
--- a/src/address/PlatformAddress.ts
+++ b/src/address/PlatformAddress.ts
@@ -4,7 +4,7 @@ import * as _ from "lodash";
 import { blake160 } from "../hash";
 import { toHex } from "../utility";
 import { H160 } from "../value/H160";
-import { H512 } from "../value/H512";
+import { H256, H256Value } from "../value/H256";
 
 import { decode, encode, fromWords, toWords } from "./bech32";
 
@@ -20,16 +20,16 @@ export type PlatformAddressValue = PlatformAddress | string;
  */
 export class PlatformAddress {
     public static fromPublic(
-        publicKey: H512 | string,
+        publicKey: H256Value,
         options: { networkId: string; version?: number }
     ): PlatformAddress {
-        if (!H512.check(publicKey)) {
+        if (!H256.check(publicKey)) {
             throw Error(
                 `Invalid public key for creating PlatformAddress: ${publicKey}`
             );
         }
         return PlatformAddress.fromAccountId(
-            getAccountIdFromPublic(H512.ensure(publicKey).value),
+            getAccountIdFromPublic(H256.ensure(publicKey).value),
             options
         );
     }

--- a/test/PlatformAddress.test.ts
+++ b/test/PlatformAddress.test.ts
@@ -96,3 +96,35 @@ describe("fromString", () => {
         }
     });
 });
+
+describe("fromPublic", () => {
+    const pubkey =
+        "d7a6d266837c1c591383b90d835068b9ed58dd3bcebd6e285911f58e40ce413c";
+    const accountId = "837cfc9c54fd1cd83970e0493d54d3a579aba06c";
+
+    test("mainnet", () => {
+        const address = PlatformAddress.fromPublic(pubkey, { networkId: "cc" });
+        expect(address.toString()).toEqual(
+            "cccqxphelyu2n73ekpewrsyj0256wjhn2aqdsdp3qs3"
+        );
+        expect(address.accountId).toEqual(new H160(accountId));
+    });
+
+    test("testnet", () => {
+        const address = PlatformAddress.fromPublic(pubkey, { networkId: "tc" });
+        expect(address.toString()).toEqual(
+            "tccqxphelyu2n73ekpewrsyj0256wjhn2aqds9xrrrg"
+        );
+        expect(address.accountId).toEqual(new H160(accountId));
+    });
+
+    test("Invalid public key", done => {
+        try {
+            PlatformAddress.fromPublic(pubkey.slice(1), { networkId: "cc" });
+            done.fail();
+        } catch (e) {
+            expect(e.toString()).toContain("Invalid public key");
+            done();
+        }
+    });
+});


### PR DESCRIPTION
Ed25519 has the public key type of 32 bytes string. It fixes the
method's argument type and adds a test suite.